### PR TITLE
Update dependencies on JSON and Rest-Client gems

### DIFF
--- a/epayco-ruby.gemspec
+++ b/epayco-ruby.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
 
   s.license           = "MIT"
   s.executables.push("epayco")
-  s.add_dependency('rest-client', '~> 1.7')
-  s.add_dependency('json', '~> 2.0')
+  s.add_dependency('rest-client', '~> 2.0')
+  s.add_dependency('json', '~> 2.1')
   s.add_development_dependency('cutest', '~> 1.2')
   s.add_development_dependency('mocha', '~> 1.1')
 


### PR DESCRIPTION
We have a gem version conflict that has to be resolved at the level of this gem in order for a production bug to be fixed in our application.

We've forked the gem, but would like to suggest merging this PR to update your dependencies.

Here is the issue we're facing, but others may encounter similar issues with other gems:

```
Bundler could not find compatible versions for gem "mime-types":
  In snapshot (Gemfile.lock):
    mime-types (= 2.99.3)

  In Gemfile:
    google-api-client (= 0.20.1) was resolved to 0.20.1, which depends on
      mime-types (~> 3.0)

    epayco-ruby was resolved to 0.0.6, which depends on
      rest-client (~> 1.7) was resolved to 1.8.0, which depends on
        mime-types (< 3.0, >= 1.16)
```

However, I couldn't get your test suite running. I ran and got the following:
```
ruby -Ilib:test tests/testing.rb
tests/testing.rb:16:in `block in <main>': Mocha methods cannot be used outside the context of a test (Mocha::NotInitializedError)
	from /Users/michaeldawson/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cutest-1.2.3/lib/cutest.rb:145:in `test'
	from tests/testing.rb:19:in `<main>'
```

Can you let me know if I'm missing something with the test suite, and if this change seems ok to you? I couldn't see anything in your code that would cause an issue with these version bumps. Also, our issue only requires the bump of the `rest-client` dependency, but I thought I'd update both to the latest stable versions.